### PR TITLE
Added SUID detection one-liner.

### DIFF
--- a/Core/payloads/linux/bash/find_suid.liner
+++ b/Core/payloads/linux/bash/find_suid.liner
@@ -1,0 +1,7 @@
+[Info]
+Author      = Nick Aliferopoulos (naliferopoulos)
+Description = Detects files with SUID bit set, starting from '/' (useful for privilege escalation)
+
+[Payload]
+Type     = PrivEsc
+Payload  = find / -perm 4000 2>/dev/null


### PR DESCRIPTION
Added **find_suid.liner**, providing a payload to detect files with UID bit set (**SUID files**) starting from '/'. The one liner also provides automatic error suppression (due to UNIX permissions) by redirecting **stderr** to **/dev/null**. Please note that I used the type "PrivEsc" to indicate that it is intended for privilege escalation usage.